### PR TITLE
Enable TLS on the Docker remote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Coming soon
 
 ## Deploy
 
-The InfraKit instance will render the ```config.tpl``` template, and watch the resulting file (config.json).
-The result will be the full Swarm cluster.
+The InfraKit instance renders the ```config.tpl``` template, and watches the resulting file (config.json).
+The result is the full Swarm cluster.
 
 ## Security
 
-To be implemented
+The Swarm cluster is by default secured with self managed certificates.
+The manager node remote API is enabled to allow nodes to get the join token, certificates are signed by a CA hosted on the bootstrap instance to enable mutual authentication.
+The certificate management is only for demonstration purpose, not for production.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 # @(#) starts infrakit and deploys the configuration
-# @(#) if no argument is provided, the configuration is expected to be $PWD
+# @(#) if no argument is provided, the configuration is expected to be in $PWD
 
-
+# Location of InfraKit templates
 InfraKitConfigurationBaseURL=$1
+# 
 INFRAKIT_HOME=/infrakit
 INFRAKIT_IMAGE=infrakit/devbundle:dev
 INFRAKIT_AWS_IMAGE=infrakit/aws:dev
+SSL_KEY_LENGTH=2048
+CERTIFICATE_SERVER_IMAGE=ndegory/certauth:latest
 
-docker pull $INFRAKIT_IMAGE
-docker pull $INFRAKIT_AWS_IMAGE
+docker pull $INFRAKIT_IMAGE || exit 1
+docker pull $INFRAKIT_AWS_IMAGE || exit 1
 
+# if a remote location is provided, first fetch the sources locally
+# and prepare an InfraKit home dir
 if [ -n "$InfraKitConfigurationBaseURL" ]; then
   LOCAL_CONFIG=$INFRAKIT_HOME
   mkdir  -p $INFRAKIT_HOME
@@ -20,31 +25,84 @@ if [ -n "$InfraKitConfigurationBaseURL" ]; then
     curl -Ls ${InfraKitConfigurationBaseURL}/$f -o $LOCAL_CONFIG/$f && echo "done" || echo "failed"
   done
 else
+# or just use the local directory as the source
   LOCAL_CONFIG=$PWD
 fi
-mkdir -p $LOCAL_CONFIG/logs $LOCAL_CONFIG/plugins $LOCAL_CONFIG/configs
+mkdir -p $LOCAL_CONFIG/logs $LOCAL_CONFIG/plugins $LOCAL_CONFIG/configs || exit 1
 
 INFRAKIT_OPTIONS="-e INFRAKIT_HOME=$INFRAKIT_HOME -v $LOCAL_CONFIG:$INFRAKIT_HOME"
 INFRAKIT_PLUGINS_OPTIONS="-v /var/run/docker.sock:/var/run/docker.sock -e INFRAKIT_PLUGINS_DIR=$INFRAKIT_HOME/plugins"
 
-echo "start InfraKit..."
+# get the local private IP, first with the AWS metadata service, and then a more standard way
+IP=$(curl -m 3 169.254.169.254/latest/meta-data/local-ipv4) || IP=$(ip a show dev eth0 | grep inet | grep eth0 | tail -1 | sed -e 's/^.*inet.//g' -e 's/\/.*$//g')
+if [ -z "$IP" ];then
+	echo "Unable to guess the private IP"
+	exit 1
+fi
+
+if [ ! -d ~/certificate.authority ]; then
+	echo "Build a certificate management service..."
+	pushd ~/
+	git clone https://github.com/ndegory/certificate.authority.git
+	pushd certificate.authority 2>/dev/null
+	docker build -t $CERTIFICATE_SERVER_IMAGE . || exit 1
+	popd -1 2>/dev/null && popd 2>/dev/null
+fi
+
+echo "Run the certificate management service..."
+docker container ls | grep -qw certauth
+if [ $? -ne 0 ]; then
+  docker run -d --restart always -p 80 --name certauth $CERTIFICATE_SERVER_IMAGE || exit 1
+fi
+CERTIFICATE_SERVER_PORT=$(docker inspect certauth --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}')
+echo "certificate server listening on port $CERTIFICATE_SERVER_PORT"
+echo "{{ global \"/certificate/ca/service\" \"$IP:$CERTIFICATE_SERVER_PORT\" }}" >> $LOCAL_CONFIG/env.ikt
+
+if [ ! -f /etc/docker/ca.pem ]; then
+        echo "Generate a self-signed CA..."
+        # (used by the Swarm flavor plugin)
+	curl localhost:$CERTIFICATE_SERVER_PORT/ca > /etc/docker/ca.pem
+        echo "Generate a certificate for the Docker client..."
+	openssl genrsa -out /etc/docker/client-key.pem $SSL_KEY_LENGTH
+	openssl req -subj '/CN=client' -new -key /etc/docker/client-key.pem -out /etc/docker/client.csr
+	curl --data "csr=$(cat /etc/docker/client.csr | sed 's/+/%2B/g');ext=extendedKeyUsage=clientAuth" localhost:$CERTIFICATE_SERVER_PORT/csr > /etc/docker/client.pem
+	ls -l /etc/docker/client.pem
+	rm -f /etc/docker/client.csr
+fi
+
 echo "group" > $LOCAL_CONFIG/leader
-docker run -d --restart always --name infrakit \
+docker container ls | grep -qw infrakit
+if [ $? -ne 0 ]; then
+    # cleanup
+    rm -f $LOCAL_CONFIG/plugins/flavor-* $LOCAL_CONFIG/plugins/group*
+    echo "start InfraKit..."
+    docker run -d --restart always --name infrakit \
+           -v /etc/docker:/etc/docker \
            $INFRAKIT_OPTIONS $INFRAKIT_PLUGINS_OPTIONS $INFRAKIT_IMAGE \
            infrakit plugin start --wait --config-url file://$INFRAKIT_HOME/plugins.json --exec os --log 5 \
            manager group-stateless flavor-swarm flavor-vanilla flavor-combo
+           sleep 3
+fi
 
-echo "start InfraKit AWS plugin..."
-docker run -d --restart always --name instance-plugin \
+docker container ls | grep -qw instance-plugin
+if [ $? -ne 0 ]; then
+    # cleanup
+    rm -f $LOCAL_CONFIG/plugins/instance-aws*
+    echo "start InfraKit AWS plugin..."
+    docker run -d --restart always --name instance-plugin \
            -v $LOCAL_CONFIG:/root/.infrakit $INFRAKIT_AWS_IMAGE \
            infrakit-instance-aws --log 5
-
-echo "wait for plugins to be ready..."
-sleep 10
+    echo "wait for plugins to be ready..."
+    sleep 5
+fi
 
 echo "prepare the InfraKit configuration file..."
 docker run --rm $INFRAKIT_OPTIONS $INFRAKIT_IMAGE \
            infrakit template --url file://$INFRAKIT_HOME/config.tpl > $LOCAL_CONFIG/config.json
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit 1
+fi
 
 echo "deploy the configuration..."
 docker run --rm $INFRAKIT_OPTIONS $INFRAKIT_PLUGINS_OPTIONS $INFRAKIT_IMAGE \

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -276,6 +276,7 @@ Resources:
         - Ref: AWS::Region
         - Ubuntu
       InstanceType: !Ref InstanceType
+      PrivateIpAddress: "192.168.2.254"
       KeyName: !Ref KeyName
       Tags:
       - Key: Name

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -186,19 +186,81 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
-        - Action: '*'
-          Effect: Allow
+        - Action: 
+          - 'ec2:Describe*'
+          - 'ec2:Get*'
+          - 'ec2:CreateTags'
           Resource: '*'
+          Effect: Allow
+        - Action: 
+          - 'ec2:RunInstances'
+          - 'ec2:StartInstances'
+          - 'ec2:StopInstances'
+          - 'ec2:RebootInstances'
+          - 'ec2:TerminateInstances'
+          - 'ec2:AttachVolume'
+          - 'ec2:DetachVolume'
+          Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*'
+          Condition: 
+            StringEquals:
+              "ec2:vpc": !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/${Vpc}"
+          Effect: Allow
+        - Action: 
+          - 'ec2:RunInstances'
+          - 'ec2:StartInstances'
+          - 'ec2:StopInstances'
+          - 'ec2:RebootInstances'
+          - 'ec2:TerminateInstances'
+          - 'ec2:AttachVolume'
+          - 'ec2:DetachVolume'
+          Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
+          Condition: 
+            StringEquals:
+              "ec2:InstanceProfile": !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/${ClusterInstanceProfile}"
+          Effect: Allow
+        - Action: 
+          - 'ec2:RunInstances'
+          Resource:
+          - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:volume/*'
+          - !Sub 'arn:aws:ec2:${AWS::Region}::image/*'
+          - !Sub 'arn:aws:ec2:${AWS::Region}::snapshot/*'
+          - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*'
+          - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:key-pair/*'
+          - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*'
+          Effect: Allow
+        - Action: 
+          - 'iam:PassRole'
+          Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ClusterRole}'
+          Effect: Allow
         Version: '2012-10-17'
       PolicyName: managers-policy
       Roles:
       - Ref: ProvisionerRole
-  InstanceProfile:
+  ProvisionerInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles:
       - Ref: ProvisionerRole
+  ClusterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        Version: '2012-10-17'
+      Path: /
+  ClusterInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+      - Ref: ClusterRole
   BootstrapInstance:
     Type: AWS::EC2::Instance
     DependsOn: PublicSubnet1
@@ -207,7 +269,7 @@ Resources:
       SecurityGroupIds:
         - !GetAtt SecurityGroup.GroupId
       AvailabilityZone: !GetAtt PublicSubnet1.AvailabilityZone
-      IamInstanceProfile: !Ref InstanceProfile
+      IamInstanceProfile: !Ref ProvisionerInstanceProfile
       ImageId:
         Fn::FindInMap:
         - AMI
@@ -250,7 +312,7 @@ Resources:
                     {{ global "/aws/securitygroupid" "${SecurityGroup}" }}
                     {{ global "/aws/amiid" "${ami}" }}
                     {{ global "/aws/instancetype" "${InstanceType}" }}
-                    {{ global "/aws/instanceprofile" "${InstanceProfile}" }}
+                    {{ global "/aws/instanceprofile" "${ClusterInstanceProfile}" }}
                     {{ global "/aws/keyname" "${KeyName}" }}
               runcmd:
                 - wget -qO- https://get.docker.com/ | sh

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -43,6 +43,7 @@ Parameters:
     ConstraintDescription: must be an URL
     Description: Base URL for InfraKit configuration. there should be a bootstrap.sh, a variables.ikt and a config.tpl file
     Default: https://raw.githubusercontent.com/ndegory/swarm-infrakit/master
+    AllowedPattern: "https?://[0-9a-z\\.-]+\\.[a-z\\.]{2,6}[/\\w\\.-]*/?"
 
 Resources:
   Vpc:
@@ -235,21 +236,22 @@ Resources:
               packages:
                 - ca-certificates
                 - jq
+                - git
                 - curl
                 - unzip
-                - awscli
               write_files:
                 - path: /infrakit/env.ikt
                   content: |
                     {{/* Global variables */}}
                     {{ global "/aws/region" "${region}" }}
                     {{ global "/aws/stackname" "${stackname}" }}
-                    {{ global "/aws/vpcid" "${vpcid}" }}
-                    {{ global "/aws/subnetid" "${subnetid}" }}
-                    {{ global "/aws/securitygroupid" "${sgid}" }}
+                    {{ global "/aws/vpcid" "${Vpc}" }}
+                    {{ global "/aws/subnetid" "${PublicSubnet1}" }}
+                    {{ global "/aws/securitygroupid" "${SecurityGroup}" }}
                     {{ global "/aws/amiid" "${ami}" }}
-                    {{ global "/aws/instancetype" "${type}" }}
-                    {{ global "/aws/keyname" "${key}" }}
+                    {{ global "/aws/instancetype" "${InstanceType}" }}
+                    {{ global "/aws/instanceprofile" "${InstanceProfile}" }}
+                    {{ global "/aws/keyname" "${KeyName}" }}
               runcmd:
                 - wget -qO- https://get.docker.com/ | sh
                 - usermod -G docker ubuntu
@@ -257,7 +259,7 @@ Resources:
                 - systemctl start docker.service
                 - curl ${InfraKitConfigurationBaseURL}/bootstrap.sh -o /usr/local/bin/bootstrap.sh
                 - bash /usr/local/bin/bootstrap.sh ${InfraKitConfigurationBaseURL}
-            - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region", vpcid: !Ref Vpc, subnetid: !Ref PublicSubnet1, sgid: !Ref SecurityGroup, type: !Ref InstanceType, key: !Ref KeyName }
+            - { ami: !FindInMap [ AMI, !Ref "AWS::Region", Ubuntu ], stackname: !Ref "AWS::StackName", region: !Ref "AWS::Region" }
 
 Metadata:
   AWS::CloudFormation::Interface:

--- a/ca.sh
+++ b/ca.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+PASSPHRASE=${1:-amp}
+SUBJ="${SUBJ:-/C=US/ST=California/L=San Jose/O=Axway/OU=AMP/CN=ssl-dev.amp.appcelerator.io}"
+EXPIRES=365
+KEYLENGTH=2048
+CERTDIR=${CERTDIR:-/etc/docker}
+
+mkdir -p "$CERTDIR"
+for f in ca-key ca; do
+  if [ -f $CERTDIR/${f}.pem ]; then
+    echo "WARNING: ${f}.pem file already exists. Aborting"
+    exit 1
+  fi
+done
+openssl genrsa -out $CERTDIR/ca-key.pem $KEYLENGTH
+openssl req -new -x509 -days $EXPIRES -key $CERTDIR/ca-key.pem -sha256 -out $CERTDIR/ca.pem -subj "$SUBJ"
+
+# generate swarm manager key and certificate
+openssl genrsa -out $CERTDIR/m1-key.pem $KEYLENGTH
+openssl req -subj "/CN=192.168.2.200" -sha256 -new -key $CERTDIR/m1-key.pem -out $CERTDIR/m1.csr
+openssl x509 -req -days $EXPIRES -sha256 -in $CERTDIR/m1.csr -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca-key.pem -CAcreateserial -out $CERTDIR/m1.pem
+
+openssl genrsa -out $CERTDIR/m2-key.pem $KEYLENGTH
+openssl req -subj "/CN=192.168.2.201" -sha256 -new -key $CERTDIR/m2-key.pem -out $CERTDIR/m2.csr
+openssl x509 -req -days $EXPIRES -sha256 -in $CERTDIR/m2.csr -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca-key.pem -CAcreateserial -out $CERTDIR/m2.pem
+
+openssl genrsa -out $CERTDIR/m3-key.pem $KEYLENGTH
+openssl req -subj "/CN=192.168.2.202" -sha256 -new -key $CERTDIR/m3-key.pem -out $CERTDIR/m3.csr
+openssl x509 -req -days $EXPIRES -sha256 -in $CERTDIR/m3.csr -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca-key.pem -CAcreateserial -out $CERTDIR/m3.pem
+
+# generate a client certificate
+openssl genrsa -out $CERTDIR/client-key.pem $KEYLENGTH
+openssl req -subj '/CN=client' -new -key $CERTDIR/client-key.pem -out $CERTDIR/client.csr
+echo extendedKeyUsage = clientAuth > extfile.cnf
+openssl x509 -req -days $EXPIRES -sha256 -in $CERTDIR/client.csr -CA $CERTDIR/ca.pem -CAkey $CERTDIR/ca-key.pem -CAcreateserial -out $CERTDIR/client.pem -extfile extfile.cnf
+
+# fix permissions
+chmod 444 *.pem
+chmod 400 *key.pem
+
+aws acm --region ${REGION:-us-west-2} import-certificate --certificate "$(cat $CERTDIR/ca.pem)" --private-key  "$(cat $CERTDIR/ca-key.pem)"
+
+for k in m1 m2 m3; do
+  aws acm --region ${REGION:-us-west-2} import-certificate --certificate "$(cat $CERTDIR/${k}.pem)" --private-key "$(cat $CERTDIR/${k}-key.pem) --certificate-chain "$(cat $CERTDIR/ca.pem)"

--- a/config.tpl
+++ b/config.tpl
@@ -87,6 +87,9 @@
               "InstanceType": "{{ ref "/aws/instancetype" }}",
               "KeyName": "{{ ref "/aws/keyname" }}",
               "SubnetId": "{{ ref "/aws/subnetid" }}",
+              {{ if ref "/aws/instanceprofile" }}"IamInstanceProfile": {
+                "Name": "{{ ref "/aws/instanceprofile" }}"
+              },{{ end }}
               "SecurityGroupIds": [ "{{ ref "/aws/securitygroupid" }}" ]
             },
             "Tags": {

--- a/config.tpl
+++ b/config.tpl
@@ -4,7 +4,7 @@
   {
     "Plugin": "group",
     "Properties": {
-      "ID": "amp-manager",
+      "ID": "amp-manager-{{ ref "/aws/vpcid" }}",
       "Properties": {
         "Allocation": {
           "LogicalIds": [
@@ -74,7 +74,7 @@
   {
     "Plugin": "group",
     "Properties": {
-      "ID": "amp-worker",
+      "ID": "amp-worker-{{ ref "/aws/vpcid" }}",
       "Properties": {
         "Allocation": {
           "Size": 2

--- a/config.tpl
+++ b/config.tpl
@@ -21,6 +21,9 @@
               "InstanceType": "{{ ref "/aws/instancetype" }}",
               "KeyName": "{{ ref "/aws/keyname" }}",
               "SubnetId": "{{ ref "/aws/subnetid" }}",
+              {{ if ref "/aws/instanceprofile" }}"IamInstanceProfile": {
+                "Name": "{{ ref "/aws/instanceprofile" }}"
+              },{{ end }}
               "SecurityGroupIds": [ "{{ ref "/aws/securitygroupid" }}" ]
             },
             "Tags": {
@@ -40,7 +43,15 @@
                   "InitScriptTemplateURL": "file://{{ ref "/infrakit/home" }}/manager-init.sh",
                   "SwarmJoinIP": "{{ ref "/m1/ip" }}",
                   "Docker" : {
-                    "Host" : "tcp://{{ ref "/m1/ip" }}:2375"
+                    {{ if not (eq 0 (len (ref "/certificate/ca/service"))) }}"Host" : "tcp://{{ ref "/m1/ip" }}:{{ ref "/docker/remoteapi/tlsport" }}",
+                    "TLS" : {
+                      "CAFile": "{{ ref "/docker/remoteapi/cafile" }}",
+                      "CertFile": "{{ ref "/docker/remoteapi/certfile" }}",
+                      "KeyFile": "{{ ref "/docker/remoteapi/keyfile" }}",
+                      "InsecureSkipVerify": false
+                    }
+                    {{ else }}"Host" : "tcp://{{ ref "/m1/ip" }}:{{ ref "/docker/remoteapi/port" }}"
+                    {{ end }}
                   }
                 }
               }, {
@@ -91,7 +102,15 @@
             "InitScriptTemplateURL": "file://{{ ref "/infrakit/home" }}/worker-init.sh",
             "SwarmJoinIP": "{{ ref "/m1/ip" }}",
             "Docker" : {
-              "Host" : "tcp://{{ ref "/m1/ip" }}:2375"
+              {{ if not (eq 0 (len (ref "/certificate/ca/service"))) }}"Host" : "tcp://{{ ref "/m1/ip" }}:{{ ref "/docker/remoteapi/tlsport" }}",
+              "TLS" : {
+                "CAFile": "{{ ref "/docker/remoteapi/cafile" }}",
+                "CertFile": "{{ ref "/docker/remoteapi/certfile" }}",
+                "KeyFile": "{{ ref "/docker/remoteapi/keyfile" }}",
+                "InsecureSkipVerify": false
+              }
+              {{ else }}"Host" : "tcp://{{ ref "/m1/ip" }}:{{ ref "/docker/remoteapi/port" }}"
+              {{ end }}
             }
           }
         }

--- a/default.ikt
+++ b/default.ikt
@@ -1,4 +1,11 @@
 {{ global "/infrakit/home" "/infrakit" }}
+{{ global "/docker/remoteapi/port" "2375" }}
+{{ global "/docker/remoteapi/tlsport" "2376" }}
+{{ global "/docker/remoteapi/cafile" "/etc/docker/ca.pem" }}
+{{ global "/docker/remoteapi/certfile" "/etc/docker/client.pem" }}
+{{ global "/docker/remoteapi/keyfile" "/etc/docker/client-key.pem" }}
+{{ global "/docker/remoteapi/srvcertfile" "/etc/docker/server.pem" }}
+{{ global "/docker/remoteapi/srvkeyfile" "/etc/docker/server-key.pem" }}
 {{ global "/amp/amplifier/image" "appcelerator/amplifier" }}
 {{ global "/amp/amplifier/version" "latest" }}
 {{ global "/amp/amplifier/replica" "3" }}

--- a/manager-init.sh
+++ b/manager-init.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
+{{ source "default.ikt" }}
+{{ source "env.ikt" }}
 wget -qO- https://get.docker.com/ | sh
 usermod -G docker ubuntu
 systemctl enable docker.service
@@ -21,12 +23,47 @@ sleep 5
 
 {{ if and ( eq INSTANCE_LOGICAL_ID SPEC.SwarmJoinIP ) (not SWARM_INITIALIZED) }}
 
-  # Tell Docker to listen on port 2375 for remote API access. This is optional.
+  {{ if not ( eq 0 (len (ref "/certificate/ca/service"))) }}
+  # get a certificate
+  # prepare the CSR with subject alt names
+  cfg=$(mktemp)
+  cp /etc/ssl/openssl.cnf $cfg
+  sed -i '/^\[ req \]$/ a\
+req_extensions = v3_req' $cfg
+  sed -i '/^\[ v3_req \]$/ a\
+subjectAltName          = @alternate_names' $cfg
+  cat >> $cfg << EOF
+
+[ alternate_names ]
+DNS.1       = $(hostname -f)
+DNS.2       = $(hostname)
+IP.1       = 192.168.2.200
+EOF
+  cacfg=$(mktemp)
+  cat >> $cacfg << EOF
+
+basicConstraints=CA:FALSE
+subjectAltName          = @alternate_names
+subjectKeyIdentifier = hash
+
+[ alternate_names ]
+DNS.1       = $(hostname -f)
+DNS.2       = $(hostname)
+IP.1       = 192.168.2.200
+EOF
+
+  openssl genrsa -out {{ ref "/docker/remoteapi/srvkeyfile" }} 2048 || exit 1
+  openssl req -subj "/CN=$(hostname)" -sha256 -new -key {{ ref "/docker/remoteapi/srvkeyfile" }} -out {{ ref "/docker/remoteapi/srvcertfile" }}.csr || exit 1
+  curl --data "csr=$(sed 's/+/%2B/g' {{ ref "/docker/remoteapi/srvcertfile" }}.csr);ext=$(cat $cacfg)"  {{ ref "/certificate/ca/service" }}/csr > {{ ref "/docker/remoteapi/srvcertfile" }}
+  curl {{ ref "/certificate/ca/service" }}/ca > {{ ref "/docker/remoteapi/cafile" }}
+  rm -f {{ ref "/docker/remoteapi/srvcertfile" }}.csr $cfg $cacfg
+  {{ end }}
+  
   mkdir -p /etc/systemd/system/docker.service.d
   cat > /etc/systemd/system/docker.service.d/docker.conf <<EOF
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:2375 -H unix:///var/run/docker.sock
+ExecStart=/usr/bin/dockerd -H fd:// -H 0.0.0.0:{{ if not (eq 0 (len (ref "/certificate/ca/service"))) }}{{ ref "/docker/remoteapi/tlsport" }} --tlsverify --tlscacert={{ ref "/docker/remoteapi/cafile" }} --tlscert={{ ref "/docker/remoteapi/srvcertfile" }} --tlskey={{ ref "/docker/remoteapi/srvkeyfile" }}{{else }}{{ ref "/docker/remoteapi/port" }}{{ end }} -H unix:///var/run/docker.sock
 EOF
 
   # Restart Docker to let port listening take effect.


### PR DESCRIPTION
- secure remote API on the manager nodes
- reduced IAM role content
- static IP for the bootstrap instance
- InfraKit group name based on the vpc id